### PR TITLE
Add --verbose option and standardize --dryrun side-effect behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ png2avif imagedir
 * ディレクトリを再帰的に走査
 * PNG → AVIF へ変換
 * 画質をオプションで指定可能
-* dryrunモード対応（変換・削除ログのみ表示）
+* dryrunモード対応（副作用のみ無効化）
+* verboseモードでファイル単位ログを表示
 * 単一PNGファイル指定も可能
 
 ---
@@ -71,7 +72,7 @@ pip install .
 ## Usage
 
 ```
-png2avif [--dryrun] [--quality QUALITY] <target_path>
+png2avif [--verbose] [--dryrun] [--quality QUALITY] <target_path>
 ```
 
 ### Arguments
@@ -80,7 +81,8 @@ png2avif [--dryrun] [--quality QUALITY] <target_path>
 | ----------- | ------------------------ |
 | target_path | 変換対象ディレクトリまたはPNGファイル（必須） |
 | --quality   | AVIF品質（0–100, デフォルト: 80） |
-| --dryrun    | 変換削除を実行せず、対象ファイルのログのみ出力          |
+| --verbose   | `converted / removed` のファイル単位ログを出力 |
+| --dryrun    | AVIF書き込みとPNG削除を行わない（副作用なし） |
 
 ---
 
@@ -90,6 +92,12 @@ png2avif [--dryrun] [--quality QUALITY] <target_path>
 
 ```
 png2avif imagedir
+```
+
+### 通常実行（ログあり）
+
+```
+png2avif --verbose imagedir
 ```
 
 ### qualityを指定
@@ -104,6 +112,12 @@ png2avif --quality 70 imagedir
 png2avif --dryrun imagedir
 ```
 
+### dryrun + verbose
+
+```
+png2avif --dryrun --verbose imagedir
+```
+
 ### dryrun + quality指定
 
 ```
@@ -112,7 +126,7 @@ png2avif --dryrun --quality 70 imagedir
 
 ---
 
-## Output Example
+## Output Example (`--verbose` 指定時のみ)
 
 ```
 converted: imagedir/sample.png -> imagedir/sample.avif
@@ -126,7 +140,8 @@ removed: imagedir/sample.png
 * 既に同名の `.avif` ファイルが存在する場合は上書きされます。
 * 透過PNG（RGBA）にも対応しています。
 * 変換成功時のみ元PNGを削除します。
-* `--dryrun` を使用すると、実際のファイル変更は行われません。
+* デフォルトではファイル単位ログは出力されません（`--verbose` 指定時のみ出力）。
+* `--dryrun` を使用すると、AVIF書き込みとPNG削除を行いません。
 * 画質を下げるとファイルサイズは小さくなりますが、画質も低下します。
 
 ---


### PR DESCRIPTION
### Motivation

- Suppress noisy per-file logs by default to improve readability when processing many files.
- Make `--dryrun` a clear non-destructive mode that disables only side effects (write/delete) while keeping normal processing flow.

### Description

- Add a new `--verbose` CLI flag and update `parse_args` to accept `--verbose`, which enables per-file `converted / removed` logs only when specified.
- Change `convert_one` signature to `convert_one(..., verbose: bool)` and emit `converted` and `removed` messages only when `verbose` is true.
- Refactor `convert_one` so that `--dryrun` skips AVIF writing and PNG deletion but still runs the conversion path (no side effects), and propagate `dryrun` and `verbose` from `main` to `convert_one`.
- Update `README.md` to document the new `--verbose` option, the revised `--dryrun` semantics, usage examples, and notes about default log behavior.

### Testing

- Ran `python -m py_compile png2avif.py` and it succeeded.
- Executed integration CLI checks on fixture PNGs for `default` (no per-file logs, files converted/deleted), `--verbose` (per-file logs shown), `--dryrun` (no side effects, no per-file logs), `--dryrun --verbose` (no side effects, per-file logs shown), and single-file `--quality` behavior; all checks passed.
- Verified output counts and sample log lines during the above runs to confirm behavior matched the specification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a3f15d40832bbc92b1e7e14c057b)