### PR TITLE
Add --jobs option and parallelize conversion with ProcessPoolExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pip install .
 ## Usage
 
 ```
-png2avif [--verbose] [--dryrun] [--quality QUALITY] <target_path>
+png2avif [--verbose] [--dryrun] [--quality QUALITY] [--jobs JOBS] <target_path>
 ```
 
 ### Arguments
@@ -81,6 +81,7 @@ png2avif [--verbose] [--dryrun] [--quality QUALITY] <target_path>
 | ----------- | ------------------------ |
 | target_path | 変換対象ディレクトリまたはPNGファイル（必須） |
 | --quality   | AVIF品質（0–100, デフォルト: 80） |
+| --jobs      | 並列ワーカープロセス数（1以上, デフォルト: 1） |
 | --verbose   | `converted / removed` のファイル単位ログを出力 |
 | --dryrun    | AVIF書き込みとPNG削除を行わない（副作用なし） |
 
@@ -124,6 +125,18 @@ png2avif --dryrun --verbose imagedir
 png2avif --dryrun --quality 70 imagedir
 ```
 
+### 4並列で実行
+
+```
+png2avif --jobs 4 imagedir
+```
+
+### 4並列 + verbose
+
+```
+png2avif --jobs 4 --verbose imagedir
+```
+
 ---
 
 ## Output Example (`--verbose` 指定時のみ)
@@ -142,6 +155,7 @@ removed: imagedir/sample.png
 * 変換成功時のみ元PNGを削除します。
 * デフォルトではファイル単位ログは出力されません（`--verbose` 指定時のみ出力）。
 * `--dryrun` を使用すると、AVIF書き込みとPNG削除を行いません。
+* `--jobs` は 1 以上を指定でき、Converting フェーズは `ProcessPoolExecutor` で実行されます（Scanning は逐次）。
 * 画質を下げるとファイルサイズは小さくなりますが、画質も低下します。
 
 ---


### PR DESCRIPTION
### Motivation

- Improve conversion throughput by allowing multiple worker processes for the Converting phase and document the option in the README.

### Description

- Add a new CLI option `--jobs` with validation to control the number of parallel worker processes (default 1).
- Replace the single-process `convert_one` flow with a worker function `_worker_convert` that runs in a worker process and returns conversion results as a tuple.
- Execute conversions via `ProcessPoolExecutor` and `as_completed`, updating the `tqdm` progress bar and emitting `converted`/`removed` logs from the main process when `--verbose` is set.
- Update `README.md` with `--jobs` usage, examples, and a note that Converting is executed with `ProcessPoolExecutor` while Scanning remains sequential.

### Testing

- No automated tests were added or present in the repository, so no automated test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b0a016d0832b81c47897abf72948)