### PR TITLE
Align AVIF metadata embedding with WebUI ReForge EXIF handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 dependencies = [
   "Pillow>=10.0.0",
   "pillow-avif-plugin>=1.4.0",
+  "piexif>=1.1.3",
   "tqdm>=4.66.0",
 ]
 


### PR DESCRIPTION
Fix #11 

### Motivation
- Preserve Stable Diffusion `parameters` from PNG when converting to AVIF in a way consistent with ReForge WebUI by embedding them into EXIF `UserComment` bytes.

### Description
- Replace custom ASCII/UTF logic with `piexif.helper.UserComment.dump(..., encoding="unicode")` to produce `UserComment` bytes in the ReForge-compatible form.
- Build an EXIF payload dict and serialize it with `piexif.dump(...)`, then pass the resulting bytes to `img.save(..., exif=...)` instead of using `Image.Exif()` and `tobytes()`.
- Add `piexif` to `pyproject.toml` as a project dependency.
- Update tests in `test/test_png2avif.py` to expect the `UNICODE` prefix + UTF-16BE payload and to verify EXIF by loading raw `exif` bytes with `piexif.load()`.

### Testing
- Ran `python -m unittest discover -s test -v` after the changes, and all tests passed (3 tests run, OK).
- During development the test run initially failed due to missing `piexif`, after adding the dependency and updating the code/tests the test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a25984f14c832bab68f324fee4899e)